### PR TITLE
Lock/Unlock compound variable now working

### DIFF
--- a/src/main/java/se/iths/remoteyourcar/routing/VehicleService.java
+++ b/src/main/java/se/iths/remoteyourcar/routing/VehicleService.java
@@ -65,7 +65,7 @@ public class VehicleService {
     public Mono<Response> unLockDoors(@Parameter(in = ParameterIn.PATH) Long id) {
         VehicleState vehicleState = repository.findById(id);
         vehicleState.getDoorState().setAllUnLocked();
-        //vehicleState.setLocked(false);  This is a bug, added for testing purposes.
+        vehicleState.setLocked(false);
 
         Response response = new Response();
         response.setReason("");


### PR DESCRIPTION
The compound boolean variable for lock status of all doors on the car didn't change status to false when unlocking the car. Fixes #1